### PR TITLE
Underlined "Build Season Hours"

### DIFF
--- a/content/home_content.php
+++ b/content/home_content.php
@@ -20,4 +20,4 @@
   <li>PNW Oregon City District Event - March 31st-April 1st, 2016</li>
 </ul>
 <br>
-<u><a href="http://team2471.org/hours/">Build Season Hours</a></u>
+<p><a href="http://team2471.org/hours/">Build Season Hours</a></p>

--- a/content/home_content.php
+++ b/content/home_content.php
@@ -20,4 +20,4 @@
   <li>PNW Oregon City District Event - March 31st-April 1st, 2016</li>
 </ul>
 <br>
-<a href="http://team2471.org/hours/">Build Season Hours</a>
+<u><a href="http://team2471.org/hours/">Build Season Hours</a></u>


### PR DESCRIPTION
Underlined "Build Season Hours" upon student request to make the link more obvious due to the similarity in styles across the website.
